### PR TITLE
fix: fix the issue of getting incomplete identifier spelling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ set(DEVELOPMENT_FLAGS
 if(ZIV_ENABLE_HARDENING)
     set(HARDENING_FLAGS
         -fstack-protector-strong
-        -Wformat 
+        -Wformat
         -Wformat-security
         -fPIC
         $<$<CXX_COMPILER_ID:Clang>:-fsanitize-cfi-cross-dso>
@@ -137,7 +137,7 @@ endif()
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2.6)
     if(CMAKE_HOST_WIN32 AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 3.7)
         list(APPEND GENERAL_COMPILE_FLAGS
-            -fansi-escape-codes 
+            -fansi-escape-codes
             -fcolor-diagnostics
         )
     else()

--- a/toolchain/lex/token_buffer.hpp
+++ b/toolchain/lex/token_buffer.hpp
@@ -39,6 +39,14 @@ public:
               column(column),
               filename(filename){};
 
+        Token(const Token& token)
+            : kind(token.kind),
+              spelling_value(token.spelling.str()),
+              spelling(spelling_value),
+              line(token.line),
+              column(token.column),
+              filename(token.filename){}
+
         static Token create_empty(TokenKind kind = TokenKind::Sof()) {
             return Token(kind, "", "", 0, 0);
         }

--- a/toolchain/lex/token_buffer.hpp
+++ b/toolchain/lex/token_buffer.hpp
@@ -37,7 +37,7 @@ public:
               spelling(spelling_value),
               line(line),
               column(column),
-              filename(filename){};
+              filename(filename) {};
 
         Token(const Token& token)
             : kind(token.kind),
@@ -45,7 +45,7 @@ public:
               spelling(spelling_value),
               line(token.line),
               column(token.column),
-              filename(token.filename){}
+              filename(token.filename) {}
 
         static Token create_empty(TokenKind kind = TokenKind::Sof()) {
             return Token(kind, "", "", 0, 0);

--- a/toolchain/lex/token_buffer.hpp
+++ b/toolchain/lex/token_buffer.hpp
@@ -37,7 +37,7 @@ public:
               spelling(spelling_value),
               line(line),
               column(column),
-              filename(filename) {};
+              filename(filename){};
 
         Token(const Token& token)
             : kind(token.kind),


### PR DESCRIPTION
- Added copy constructor for Token type in order to properly copy reference used by llvm::StringRef spelling

Fixes #22

<!--
Part of the Ziv Programming Language, under the Apache License v2.0 with LLVM
See /LICENSE for license details.
SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-->

<!-- Please describe the changes made in this PR. Provide any relevant details, code examples, or documentation updates. -->

## Checklist for Contributor

Please confirm that you have completed the following tasks by checking the boxes:

- [x] I have read and followed the project's [contribution guidelines](../CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I will be responsible for the changes introduced in this PR and provide support if issues arise.
- [x] I acknowledge that any future updates or bug fixes related to this code will be my responsibility.

## Checklist for Reviewer

Please confirm that you have completed the following tasks by checking the boxes:

- [x] I have reviewed the code thoroughly and approve the changes.
- [x] I will assist the contributor if any issues arise after this code is merged.
- [x] I confirm that this PR is ready for merging once all conditions are met.

---

**NOTE:** This PR cannot be merged until all checkboxes are marked as completed.
